### PR TITLE
Revert "Ismith.rename api key write key"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ module "my-cloudwatch-metrics" {
 
   name = "my-cloudwatch-metrics"
   honeycomb_dataset_name = "my-cloudwatch-metrics"
-  honeycomb_writekey = "HONEYCOMB_WRITEKEY"
+  honeycomb_api_key = "HONEYCOMB_API_KEY"
 }
 ```
 
@@ -37,7 +37,7 @@ Test cases are in [`tests/`](tests/). To setup:
 1. Edit the `provider "aws"` block to fit your credentials.
 
 2. Create a `test.auto.tfvars` file in `tests/` with values for
-   `honeycomb_writekey` and, optionally, `honeycomb_api_host`.
+   `honeycomb_api_key` and, optionally, `honeycomb_api_host`.
 
 3. `terraform plan` and `terraform apply` will now work as expected, as will
    `terraform destroy`.

--- a/USAGE.md
+++ b/USAGE.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.42.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | > 0.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | > 0.0.0 |
 
 ## Modules
 
@@ -33,8 +33,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_honeycomb_api_host"></a> [honeycomb\_api\_host](#input\_honeycomb\_api\_host) | If you use a Secure Tenancy or other proxy, put its schema://host[:port] here. | `string` | `"https://api.honeycomb.io"` | no |
+| <a name="input_honeycomb_api_key"></a> [honeycomb\_api\_key](#input\_honeycomb\_api\_key) | Your Honeycomb team's API key. | `string` | n/a | yes |
 | <a name="input_honeycomb_dataset_name"></a> [honeycomb\_dataset\_name](#input\_honeycomb\_dataset\_name) | Your Honeycomb dataset name. | `string` | n/a | yes |
-| <a name="input_honeycomb_writekey"></a> [honeycomb\_writekey](#input\_honeycomb\_writekey) | Your Honeycomb team's writekey/API key. | `string` | n/a | yes |
 | <a name="input_http_buffering_interval"></a> [http\_buffering\_interval](#input\_http\_buffering\_interval) | Kinesis Firehose http buffer interval, in seconds. | `number` | `60` | no |
 | <a name="input_http_buffering_size"></a> [http\_buffering\_size](#input\_http\_buffering\_size) | Kinesis Firehose http buffer size, in MiB. | `number` | `15` | no |
 | <a name="input_name"></a> [name](#input\_name) | A name for this CloudWatch Metric Stream. | `string` | n/a | yes |

--- a/examples/default.tf
+++ b/examples/default.tf
@@ -4,7 +4,7 @@ module "cloudwatch_metric_stream_default" {
   name                   = "cms_default"
   honeycomb_dataset_name = "cloudwatch-default"
 
-  honeycomb_writekey = var.honeycomb_writekey
+  honeycomb_api_key = var.honeycomb_api_key
 
   # Users generally don't need to set this unless they're using Secure Tenancy,
   # but it's here to enable our tests to run.

--- a/examples/with-exclude-filters.tf
+++ b/examples/with-exclude-filters.tf
@@ -4,7 +4,7 @@ module "cloudwatch_metric_stream_with_excludes" {
   name                   = "cms_with_excludes"
   honeycomb_dataset_name = "cloudwatch-with-excludes"
 
-  honeycomb_writekey = var.honeycomb_writekey
+  honeycomb_api_key = var.honeycomb_api_key
 
   # Users generally don't need to set this unless they're using Secure Tenancy,
   # but it's here to enable our tests to run.

--- a/examples/with-include-filters.tf
+++ b/examples/with-include-filters.tf
@@ -4,7 +4,7 @@ module "cloudwatch_metric_stream_with_includes" {
   name                   = "cms_with_includes"
   honeycomb_dataset_name = "cloudwatch-with-includes"
 
-  honeycomb_writekey = var.honeycomb_writekey
+  honeycomb_api_key = var.honeycomb_api_key
 
   # Users generally don't need to set this unless they're using Secure Tenancy,
   # but it's here to enable our tests to run.

--- a/examples/with-tags.tf
+++ b/examples/with-tags.tf
@@ -4,7 +4,7 @@ module "cloudwatch_metric_stream_with_tags" {
   name                   = "cms_with_tags"
   honeycomb_dataset_name = "cloudwatch-with-tags"
 
-  honeycomb_writekey = var.honeycomb_writekey
+  honeycomb_api_key = var.honeycomb_api_key
 
   # Users generally don't need to set this unless they're using Secure Tenancy,
   # but it's here to enable our tests to run.

--- a/main.tf
+++ b/main.tf
@@ -112,7 +112,7 @@ resource "aws_kinesis_firehose_delivery_stream" "metrics" {
     url  = "${var.honeycomb_api_host}/1/kinesis_events/${var.honeycomb_dataset_name}"
     name = "Honeycomb-${var.honeycomb_dataset_name}"
 
-    access_key         = var.honeycomb_writekey
+    access_key         = var.honeycomb_api_key
     buffering_size     = var.http_buffering_size
     buffering_interval = var.http_buffering_interval
     role_arn           = aws_iam_role.firehose_to_s3.arn

--- a/tests/base.tf
+++ b/tests/base.tf
@@ -4,7 +4,7 @@ provider "aws" {
   shared_credentials_file = pathexpand("~/aws/credentials")
 }
 
-variable "honeycomb_writekey" {
+variable "honeycomb_api_key" {
   type = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,9 +15,9 @@ variable "honeycomb_dataset_name" {
   description = "Your Honeycomb dataset name."
 }
 
-variable "honeycomb_writekey" {
+variable "honeycomb_api_key" {
   type        = string
-  description = "Your Honeycomb team's writekey/API key."
+  description = "Your Honeycomb team's API key."
 }
 
 


### PR DESCRIPTION
Reverts honeycombio/terraform-aws-honeycomb-cloudwatch-metric-stream#13

Oops, api key is preferred: 
![image](https://user-images.githubusercontent.com/172694/119399958-64f3a880-bc8e-11eb-83cf-a93e4f289a69.png)
