### PR TITLE
[docs]: add TF_VAR usage to load api key from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,17 @@ module "my-cloudwatch-metrics" {
 }
 ```
 
-Ensure the environment variable `TF_VAR_honeycomb_api_key` is exported on the system.
+You can load terraform variables from the system by ensuring the environment variable `TF_VAR_honeycomb_api_key` is exported on the system.
+```bash
+export TF_VAR_honeycomb_api_key=$HONEYCOMB_API_KEY
+```
 
 Additionally, in `variables.tf` you can include an empty placeholder to the variable.
 ```hcl
 variable "honeycomb_api_key" {}
 ```
+
+Now when you run `terraform plan/apply` you will not be prompted for your API key during the sequence.
 
 For more config options, including resource tagging and namespace
 include/exclude filters, see [USAGE.md](USAGE.md).


### PR DESCRIPTION
Update documentation to show usage for using an environment variable to load the API key so it's not hardcoded within the config.

Terraform supports this with `TF_VAR_` so I added an example how to implement and use this with `honeycomb_api_key`.