### PR TITLE
No need to prefix our sources with app.terraform.io once the module is in the public registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module creates resources to send your CloudWatch Metrics to
 The minimal config is:
 ```hcl
 module "my-cloudwatch-metrics" {
-  source = "app.terraform.io/honeycomb/honeycomb-cloudwatch-metric-stream/aws"
+  source = "honeycomb/honeycomb-cloudwatch-metric-stream/aws"
 
   name = "my-cloudwatch-metrics"
   honeycomb_dataset_name = "my-cloudwatch-metrics"

--- a/examples/default.tf
+++ b/examples/default.tf
@@ -1,5 +1,5 @@
 module "cloudwatch_metric_stream_default" {
-  source = "app.terraform.io/honeycomb/honeycomb-cloudwatch-metric-stream/aws"
+  source = "honeycomb/honeycomb-cloudwatch-metric-stream/aws"
 
   name                   = "cms_default"
   honeycomb_dataset_name = "cloudwatch-default"

--- a/examples/with-exclude-filters.tf
+++ b/examples/with-exclude-filters.tf
@@ -1,5 +1,5 @@
 module "cloudwatch_metric_stream_with_excludes" {
-  source = "app.terraform.io/honeycomb/honeycomb-cloudwatch-metric-stream/aws"
+  source = "honeycomb/honeycomb-cloudwatch-metric-stream/aws"
 
   name                   = "cms_with_excludes"
   honeycomb_dataset_name = "cloudwatch-with-excludes"

--- a/examples/with-include-filters.tf
+++ b/examples/with-include-filters.tf
@@ -1,5 +1,5 @@
 module "cloudwatch_metric_stream_with_includes" {
-  source = "app.terraform.io/honeycomb/honeycomb-cloudwatch-metric-stream/aws"
+  source = "honeycomb/honeycomb-cloudwatch-metric-stream/aws"
 
   name                   = "cms_with_includes"
   honeycomb_dataset_name = "cloudwatch-with-includes"

--- a/examples/with-tags.tf
+++ b/examples/with-tags.tf
@@ -1,5 +1,5 @@
 module "cloudwatch_metric_stream_with_tags" {
-  source = "app.terraform.io/honeycomb/honeycomb-cloudwatch-metric-stream/aws"
+  source = "honeycomb/honeycomb-cloudwatch-metric-stream/aws"
 
   name                   = "cms_with_tags"
   honeycomb_dataset_name = "cloudwatch-with-tags"


### PR DESCRIPTION
**Asana:**
https://app.asana.com/0/1188408832745204/1200319907426032