### PR TITLE
Update AWS provider constrains to take AWS v4 S3 Bucket Refactor into account

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | > 0.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.42.0, >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | > 0.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.42.0, >= 4.9.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,9 @@
 terraform {
-  # TODO: not sure we need >= 0.13! But it's what we've tested against.
   required_version = ">= 0.13"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.42.0"
+      version = ">= 3.42.0, >= 4.9.0"
     }
   }
 }


### PR DESCRIPTION
Prior to v4.9.0 of the AWS provider the S3 bucket resource had a handful of breaking changes. This change will allow compatible v3 and v4 versions of the AWS provider to use this module safely.

Closes #19, #20