### PR TITLE
Properly exclude AWS provider versions 4.0->4.8

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.42.0, >= 4.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.42.0, < 4.0, >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.42.0, >= 4.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.42.0, < 4.0, >= 4.9.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.42.0, >= 4.9.0"
+      version = ">= 3.42.0, != 4.0.0, != 4.1.0, != 4.2.0, != 4.3.0, != 4.4.0, != 4.5.0, != 4.6.0, != 4.7.0, != 4.8.0"
     }
   }
 }


### PR DESCRIPTION
Previous fix did not allow v3 providers to be in use :\